### PR TITLE
Fix module load wine and turbovnc

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -390,7 +390,8 @@ class Session < ActiveRecord::Base
       xstartup: paraview_assets.join('xstartup'),
       outdir: paraview_outdir,
       geom: "#{resx}x#{resy}",
-      tcp_server?: false
+      tcp_server?: false,
+      load_turbovnc: "module load intel/16.0.3 turbovnc/2.0.91"
     )
   end
 
@@ -496,7 +497,8 @@ class Session < ActiveRecord::Base
         'ruby',
         xstartup: vftsolid_assets.join('xstartup'),
         outdir: staged_dir,
-        geom: "#{resx}x#{resy}"
+        geom: "#{resx}x#{resy}",
+        load_turbovnc: "module load intel/16.0.3 turbovnc/2.0.91"
       )
     end
 

--- a/jobs/vftsolid/bin/launch_vftsolid.sh
+++ b/jobs/vftsolid/bin/launch_vftsolid.sh
@@ -4,7 +4,7 @@ FvwmCommand "Restart"
 
 . /etc/profile.d/lmod.sh
 module use /users/PZS0645/wiag/local-ruby/share/modulefiles
-module load wine
+module load wine/1.8.6
 module use /users/PZS0645/wiag/local-ruby/emc2/share/modulefiles
 module load ctsp    # necessary for writing out WARP3D cut
 module load vft/i686


### PR DESCRIPTION
1. the software refresh broke loading the older turbovnc without first
   loading the intel 16 compiler
2. the version of wine not being specified so when the new 64 bit version
   was installed that was being loaded instead of the existing 32 bit
   versions